### PR TITLE
fix(authors): make authors/organization a list instead of object

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -49,7 +49,7 @@ collections:
         widget: "string"
       - name: "organizations"
         label: "Organizations/Affiliations"
-        widget: "object"
+        widget: "list"
         fields:
           - name: "name"
             label: "Organization Name"


### PR DESCRIPTION
The authors field organization is a list of organizations.