### PR TITLE
fix(netlifycms): change post collection field categories to list

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -123,7 +123,7 @@ collections:
         searchFields: ["name"]
         valueField: "name"
         displayFields: ["name"]
-        multiple: false
+        multiple: true
         required: false
       - name: "editions"
         label: "Editions"


### PR DESCRIPTION
Allow multiple categories to be applied to a blog post and there be a list and not a simple string.